### PR TITLE
feat: Add 'learn monaco' documentation sample project

### DIFF
--- a/learn-monaco-auto-tag/README.md
+++ b/learn-monaco-auto-tag/README.md
@@ -1,0 +1,5 @@
+# Getting started sample
+
+This sample project provides a reference for the [Deploy your first configuration](https://www.dynatrace.com/support/help/shortlink/configuration-as-code-manage-configuration) guide from the documentation.
+
+To run it, you will need to modify the URL in the manifest file and export an API token as environment variable `devToken`.

--- a/learn-monaco-auto-tag/delete.yaml
+++ b/learn-monaco-auto-tag/delete.yaml
@@ -1,0 +1,4 @@
+delete:
+  - project: "auto-tag"
+    type: auto-tag
+    name: "DTServer"

--- a/learn-monaco-auto-tag/manifest.yaml
+++ b/learn-monaco-auto-tag/manifest.yaml
@@ -1,0 +1,14 @@
+   manifestVersion: 1.0
+   projects:
+     - name: auto-tag
+       path: project-example
+
+   environmentGroups:
+     - name: development
+       environments:
+         - name: development-environment
+           url:
+             value: "https://<your-dynatrace-environment>.live.dynatrace.com"
+           auth:
+             token:
+               name: "devToken"

--- a/learn-monaco-auto-tag/project-example/auto-tag/auto-tag.json
+++ b/learn-monaco-auto-tag/project-example/auto-tag/auto-tag.json
@@ -1,0 +1,24 @@
+{
+    "name": "{{ .name }}",
+    "rules": [
+      {
+        "enabled": true,
+        "valueNormalization": "Leave text as-is",
+        "type": "ME",
+        "attributeRule": {
+          "entityType": "PROCESS_GROUP",
+          "conditions": [
+            {
+              "key": "PROCESS_GROUP_PREDEFINED_METADATA",
+              "dynamicKey": "DYNATRACE_CLUSTER_ID",
+              "operator": "BEGINS_WITH",
+              "stringValue": "Server on Cluster",
+              "caseSensitive": true
+            }
+          ],
+          "pgToHostPropagation": true,
+          "pgToServicePropagation": true
+        }
+      }
+    ]
+}

--- a/learn-monaco-auto-tag/project-example/auto-tag/auto-tag.yaml
+++ b/learn-monaco-auto-tag/project-example/auto-tag/auto-tag.yaml
@@ -1,0 +1,9 @@
+configs:
+  - id: application-tagging
+    type:
+      settings:
+        schema: builtin:tags.auto-tagging
+        scope: environment
+    config:
+      template: "auto-tag.json"
+      name: "DTServer"


### PR DESCRIPTION
This adds the sample from the documentation (https://www.dynatrace.com/support/help/shortlink/configuration-as-code-manage-configuration) as a reference