### PR TITLE
VM-Right-Sizing example 

### DIFF
--- a/VM-RIght-Sizing/README.md
+++ b/VM-RIght-Sizing/README.md
@@ -10,15 +10,14 @@ Monaco will deploy 4 different configurations - Slack for Workflows, Jira for Wo
 
 Here's a breakdown of what each workflow will do:
 
-    1. **Host Resize - Calculate & Ticket** will use DQL to query the current CPU usage for hosts that belong to an Azure environment. It will also use a filter that will only take hosts that are either using above 90% or below 15% of CPU at any given time. 
-    2. Workflow will open a Jira ticket(**using Jira for workflows**) with hosts that need to be resized.
+    1. Host Resize - Calculate & Ticket will use DQL to query the current CPU usage for hosts that belong to an Azure environment. It will also use a filter that will only take hosts that are either using above 90% or below 15% of CPU at any given time. 
+    2. Workflow will open a Jira ticket(using Jira for workflows) with hosts that need to be resized.
     3. Workflow will move the ticket to pending automatically so it can be worked at.
     4. Workflow will send a notification to a slack channel(using Slack for workflows).
     5. In the Jira project, you need to go and define an automation that will react to the ticket that got moved to pending and send a POST event back to Dynatrace.
-       - First automation - Auto approve pending - When issue transitioned from **Open** to **Pending** > **Approve** it. (Skip if there's a team who does this manually)
+       - First automation - Auto approve pending - When issue transitioned from Open to Pending > Approve it. (Skip if there's a team who does this manually)
        - Second automation - Post event for approval - When approved by previous automation(or team) > Send web request (URL - e.g. https://<tenantId>.apps.dynatrace.com/api/v2/events/ingest)
         Payload:
-        ```
                     {
                 "eventType": "CUSTOM_INFO",
                 "title": "Jira approval granted: {{issue.key}}",
@@ -29,8 +28,7 @@ Here's a breakdown of what each workflow will do:
                    "issuedescription": "{{issue.description.replaceAll("(\n)",",")}}"
                       }
                     }
-        ```
-    6. **Host Resize - Event Triggered** will react to the event that Jira automation sent and use DQL to query, extract certain information, and make a decision which hosts need to be resied.
+    6. Host Resize - Event Triggered will react to the event that Jira automation sent and use DQL to query, extract certain information, and make a decision which hosts need to be resied.
     7. Workflow will obtain a bearer token.
     8. Workflow will upsize/downize a Host based on certain conditions from previous steps.
     9. Workflow will close the Jira ticket.

--- a/VM-RIght-Sizing/README.md
+++ b/VM-RIght-Sizing/README.md
@@ -1,12 +1,12 @@
-#Dynatrace VM Right-Sizing Example
+# Dynatrace VM Right-Sizing Example
 
 This repository will help you deploy a configuration that will right-size your infrastructure using Dynatrace Automation Workflows. All configuration is deployed automatically using Dynatrace Configuration as Code solution Monaco.
 
-##Description 
+## Description 
 
 The example will help you detect improperly sized hosts, trigger an approval workflow in external tools such as Jira, ServiceNow ... and then react to that approval with a workflow to right-size the environment based on metadata stored in tags by calling the respective infrastructure automation APIs such as Azure, GCP, AWS, Kubernetes, OpenShift, VMWare, Ansible.
 
-##Getting started with VM-Right-Sizing
+## Getting started with VM-Right-Sizing
 
 To get started with Dynatrace Configuration as Code please see [the documentation](https://www.dynatrace.com/support/help/setup-and-configuration/monitoring-as-code).
 

--- a/VM-RIght-Sizing/README.md
+++ b/VM-RIght-Sizing/README.md
@@ -9,14 +9,16 @@ The example will help you detect improperly sized hosts, trigger an approval wor
 Monaco will deploy 4 different configurations - Slack for Workflows, Jira for Workflows and two Workflows(Host Resize - Calculate & Ticket and Host Resize - Event Triggered). 
 
 Here's a breakdown of what each workflow will do:
-    1. "Host Resize - Calculate & Ticket" will use DQL to query the current CPU usage for hosts that belong to an Azure environment. It will also use a filter that will only take hosts that are either using above 90% or below 15% of CPU at any given time. 
-    2. Workflow will open a Jira ticket(using Jira for workflows) with hosts that need to be resized.
+
+    1. **Host Resize - Calculate & Ticket** will use DQL to query the current CPU usage for hosts that belong to an Azure environment. It will also use a filter that will only take hosts that are either using above 90% or below 15% of CPU at any given time. 
+    2. Workflow will open a Jira ticket(**using Jira for workflows**) with hosts that need to be resized.
     3. Workflow will move the ticket to pending automatically so it can be worked at.
     4. Workflow will send a notification to a slack channel(using Slack for workflows).
     5. In the Jira project, you need to go and define an automation that will react to the ticket that got moved to pending and send a POST event back to Dynatrace.
-        - First automation - Auto approve pending - When issue transitioned from Open to Pending > Approve it. (Skip if there's a team who does this manually)
-        - Second automation - Post event for approval - When approved by previous automation(or team) > Send web request (URL - e.g. https://<tenantId>.apps.dynatrace.com/api/v2/events/ingest)
+       - First automation - Auto approve pending - When issue transitioned from **Open** to **Pending** > **Approve** it. (Skip if there's a team who does this manually)
+       - Second automation - Post event for approval - When approved by previous automation(or team) > Send web request (URL - e.g. https://<tenantId>.apps.dynatrace.com/api/v2/events/ingest)
         Payload:
+        ```
                     {
                 "eventType": "CUSTOM_INFO",
                 "title": "Jira approval granted: {{issue.key}}",
@@ -27,7 +29,8 @@ Here's a breakdown of what each workflow will do:
                    "issuedescription": "{{issue.description.replaceAll("(\n)",",")}}"
                       }
                     }
-    6. "Host Resize - Event Triggered" will react to the event that Jira automation sent and use DQL to query, extract certain information, and make a decision which hosts need to be resied.
+        ```
+    6. **Host Resize - Event Triggered** will react to the event that Jira automation sent and use DQL to query, extract certain information, and make a decision which hosts need to be resied.
     7. Workflow will obtain a bearer token.
     8. Workflow will upsize/downize a Host based on certain conditions from previous steps.
     9. Workflow will close the Jira ticket.

--- a/VM-RIght-Sizing/README.md
+++ b/VM-RIght-Sizing/README.md
@@ -18,9 +18,9 @@ After your Monaco setup is done and you have some practice, feel free to deploy 
 To deploy it, please follow the steps below:
 
     1. Fill out the input-needed.sh as well as the environment url in the manifest.yaml file.   
-    1. Run the script to record the values
-    1. Run the monaco project
-    1. Go to Settings>Dynatrace Apps>Slack/Jira to check your Slack and Jira connections and go to the new Workflows apps to check your 2 newly created workflows. 
+    2. Run the script to record the values
+    3. Run the monaco project
+    4. Go to Settings>Dynatrace Apps>Slack/Jira to check your Slack and Jira connections and go to the new Workflows apps to check your 2 newly created workflows. 
 
 In case you need to delete the configuration, feel free to run the monaco delete command with the delete.yaml.
 

--- a/VM-RIght-Sizing/README.md
+++ b/VM-RIght-Sizing/README.md
@@ -6,6 +6,8 @@ This repository will help you deploy a configuration that will right-size your i
 
 The example will help you detect improperly sized hosts, trigger an approval workflow in external tools such as Jira, ServiceNow ... and then react to that approval with a workflow to right-size the environment based on metadata stored in tags by calling the respective infrastructure automation APIs such as Azure, GCP, AWS, Kubernetes, OpenShift, VMWare, Ansible.
 
+To learn more about this use case, check out the [Dynatrace Tips & Tricks Community Episode](https://youtu.be/dGWlnd1lNGQ).
+
 ## Getting started with VM-Right-Sizing
 
 To get started with Dynatrace Configuration as Code please see [the documentation](https://www.dynatrace.com/support/help/setup-and-configuration/monitoring-as-code).

--- a/VM-RIght-Sizing/README.md
+++ b/VM-RIght-Sizing/README.md
@@ -6,6 +6,32 @@ This repository will help you deploy a configuration that will right-size your i
 
 The example will help you detect improperly sized hosts, trigger an approval workflow in external tools such as Jira, ServiceNow ... and then react to that approval with a workflow to right-size the environment based on metadata stored in tags by calling the respective infrastructure automation APIs such as Azure, GCP, AWS, Kubernetes, OpenShift, VMWare, Ansible.
 
+Monaco will deploy 4 different configurations - Slack for Workflows, Jira for Workflows and two Workflows(Host Resize - Calculate & Ticket and Host Resize - Event Triggered). 
+
+Here's a breakdown of what each workflow will do:
+    1. "Host Resize - Calculate & Ticket" will use DQL to query the current CPU usage for hosts that belong to an Azure environment. It will also use a filter that will only take hosts that are either using above 90% or below 15% of CPU at any given time. 
+    2. Workflow will open a Jira ticket(using Jira for workflows) with hosts that need to be resized.
+    3. Workflow will move the ticket to pending automatically so it can be worked at.
+    4. Workflow will send a notification to a slack channel(using Slack for workflows).
+    5. In the Jira project, you need to go and define an automation that will react to the ticket that got moved to pending and send a POST event back to Dynatrace.
+        - First automation - Auto approve pending - When issue transitioned from Open to Pending > Approve it. (Skip if there's a team who does this manually)
+        - Second automation - Post event for approval - When approved by previous automation(or team) > Send web request (URL - e.g. https://<tenantId>.apps.dynatrace.com/api/v2/events/ingest)
+        Payload:
+                    {
+                "eventType": "CUSTOM_INFO",
+                "title": "Jira approval granted: {{issue.key}}",
+                "properties": {
+                   "issuekey": "{{issue.key}}",
+                   "issueurl": "{{issue.url}}",
+                   "issueid": "{{issue.id}}",
+                   "issuedescription": "{{issue.description.replaceAll("(\n)",",")}}"
+                      }
+                    }
+    6. "Host Resize - Event Triggered" will react to the event that Jira automation sent and use DQL to query, extract certain information, and make a decision which hosts need to be resied.
+    7. Workflow will obtain a bearer token.
+    8. Workflow will upsize/downize a Host based on certain conditions from previous steps.
+    9. Workflow will close the Jira ticket.
+
 To learn more about this use case, check out the [Dynatrace Tips & Tricks Community Episode](https://youtu.be/dGWlnd1lNGQ).
 
 ## Getting started with VM-Right-Sizing

--- a/VM-RIght-Sizing/README.md
+++ b/VM-RIght-Sizing/README.md
@@ -16,10 +16,11 @@ If you're new to Monaco and want to learn more, check out the [Observability Cli
 
 After your Monaco setup is done and you have some practice, feel free to deploy this configuration and explore it in your tenant. 
 To deploy it, please follow the steps below:
+
     1. Fill out the input-needed.sh as well as the environment url in the manifest.yaml file.   
-    2. Run the script to record the values
-    3. Run the monaco project
-    4. Go to Settings>Dynatrace Apps>Slack/Jira to check your Slack and Jira connections and go to the new Workflows apps to check your 2 newly created workflows. 
+    1. Run the script to record the values
+    1. Run the monaco project
+    1. Go to Settings>Dynatrace Apps>Slack/Jira to check your Slack and Jira connections and go to the new Workflows apps to check your 2 newly created workflows. 
 
 In case you need to delete the configuration, feel free to run the monaco delete command with the delete.yaml.
 

--- a/VM-RIght-Sizing/README.md
+++ b/VM-RIght-Sizing/README.md
@@ -1,0 +1,27 @@
+#Dynatrace VM Right-Sizing Example
+
+This repository will help you deploy a configuration that will right-size your infrastructure using Dynatrace Automation Workflows. All configuration is deployed automatically using Dynatrace Configuration as Code solution Monaco.
+
+##Description 
+
+The example will help you detect improperly sized hosts, trigger an approval workflow in external tools such as Jira, ServiceNow ... and then react to that approval with a workflow to right-size the environment based on metadata stored in tags by calling the respective infrastructure automation APIs such as Azure, GCP, AWS, Kubernetes, OpenShift, VMWare, Ansible.
+
+##Getting started with VM-Right-Sizing
+
+To get started with Dynatrace Configuration as Code please see [the documentation](https://www.dynatrace.com/support/help/setup-and-configuration/monitoring-as-code).
+
+To download the CLI, head over to the [dynatrace-configuration-as-code GitHub repository](https://github.com/Dynatrace/dynatrace-configuration-as-code/releases).
+
+If you're new to Monaco and want to learn more, check out the [Observability Clinic on Monaco 2.0](https://dt-url.net/monaco-observability-clinic).
+
+After your Monaco setup is done and you have some practice, feel free to deploy this configuration and explore it in your tenant. 
+To deploy it, please follow the steps below:
+    1. Fill out the input-needed.sh as well as the environment url in the manifest.yaml file.   
+    2. Run the script to record the values
+    3. Run the monaco project
+    4. Go to Settings>Dynatrace Apps>Slack/Jira to check your Slack and Jira connections and go to the new Workflows apps to check your 2 newly created workflows. 
+
+In case you need to delete the configuration, feel free to run the monaco delete command with the delete.yaml.
+
+Author: Danilo Vukotic - danilo.vukotic@dynatrace.com
+

--- a/VM-RIght-Sizing/deletefiles/delete.yaml
+++ b/VM-RIght-Sizing/deletefiles/delete.yaml
@@ -1,0 +1,13 @@
+delete:
+- project: jira-connection
+  type: app:dynatrace.jira:connection
+  id: my.jira.connection
+- project: slack-connection
+  type: app:dynatrace.slack:connection
+  id: my.slack.connection
+- project: workflow-calculate-ticket
+  type: workflow
+  id: my.workflow
+- project: workflow-calculate-ticket
+  type: workflow
+  id: my.workflow.event

--- a/VM-RIght-Sizing/first-example/jira-connection/jira-connection.json
+++ b/VM-RIght-Sizing/first-example/jira-connection/jira-connection.json
@@ -1,0 +1,7 @@
+{
+        "name": "Connection wf_host_resize Jira",
+        "url": "{{ .jiraUrl }}",
+        "type": "cloud-token",
+        "user": "{{ .userEmail }}",
+        "token": "{{ .jiraToken }}"
+}

--- a/VM-RIght-Sizing/first-example/jira-connection/jira-connection.yaml
+++ b/VM-RIght-Sizing/first-example/jira-connection/jira-connection.yaml
@@ -1,0 +1,21 @@
+configs:
+- id: my.jira.connection
+  config:
+    name: my.jira.connection
+    template: jira-connection.json
+    parameters:
+      jiraUrl:
+        type: environment
+        name: JIRA_URL
+      userEmail:
+        type: environment
+        name: USER_EMAIL
+      jiraToken:
+        type: environment
+        name: JIRA_TOKEN
+    skip: false
+  type:
+    settings:
+      schema: "app:dynatrace.jira:connection"
+      schemaVersion: 0.0.9
+      scope: environment

--- a/VM-RIght-Sizing/manifest.yaml
+++ b/VM-RIght-Sizing/manifest.yaml
@@ -12,7 +12,8 @@ environmentGroups:
     environments:
       - name: production-environment
         url:
-          value: "" # Enter environment ID e.g. https://<tenantId>.apps.dynatrace.com/
+          type: environment
+          value: DT_URL
         auth:
           token:
             type: environment

--- a/VM-RIght-Sizing/manifest.yaml
+++ b/VM-RIght-Sizing/manifest.yaml
@@ -25,6 +25,3 @@ environmentGroups:
             clientSecret:
               type: environment
               name: DT_OAUTH_CLIENT_SECRET
-            tokenEndpoint:
-              type: environment
-              value: DT_OAUTH_SSO_ENDPOINT

--- a/VM-RIght-Sizing/manifest.yaml
+++ b/VM-RIght-Sizing/manifest.yaml
@@ -1,0 +1,29 @@
+manifestVersion: 1.0
+projects:
+  - name: jira-connection
+    path: first-example
+  - name: slack-connection
+    path: second-example
+  - name: workflow-calculate-ticket
+    path: third-example
+
+environmentGroups:
+  - name: production
+    environments:
+      - name: production-environment
+        url:
+          value: "" # Enter environment ID e.g. https://<tenantId>.apps.dynatrace.com/
+        auth:
+          token:
+            type: environment
+            name: DT_API_TOKEN
+          oAuth:
+            clientId:
+              type: environment
+              name: DT_OAUTH_CLIENT_ID
+            clientSecret:
+              type: environment
+              name: DT_OAUTH_CLIENT_SECRET
+            tokenEndpoint:
+              type: environment
+              value: DT_OAUTH_SSO_ENDPOINT

--- a/VM-RIght-Sizing/script/input-needed.sh
+++ b/VM-RIght-Sizing/script/input-needed.sh
@@ -1,0 +1,44 @@
+#!/bin/zsh 
+#  ^^ - change to SH if needed
+
+#Customer inputs - Jira and Slack app connections
+export JIRA_URL=""                      # Jira Connection url e.g. https://<url>.atlassian.net
+export USER_EMAIL="" 
+export JIRA_TOKEN=""                    # Jira token for connection
+export SLACK_BOT_TOKEN=""               # Slack bot app token
+
+#Customer input - Workflow json
+export SLACK_CHANNEL=""                 # ID of the Slack channel notifications should go to
+export JIRA_PROJECT=""                  # Jira Project ID
+export JIRA_ISSUE_TYPE="" -             # Jira issue type in an ID format
+export JIRA_TICKET_REPORTER=""          # Jira ticket reporter in an ID format
+export JIRA_TRANSITION_STATUS=""        # Jira transition status in an ID format
+export AZURE_TENANT_ID="" 
+export BEARER_CLIENT_ID=""              # Payload for bearer token - client ID
+export BEARER_SCOPE=""                  # Payload for bearer token - scope e.g. https%3A%2F%2Fmanagement.azure.com%2F.default
+export BEARER_CLIENT_SECRET=""          # Payload for bearer token - client secret
+
+#Dynatrace variables needed
+export DT_API_TOKEN=""                  # Dynatrace API token - Check prerequisite here (https://www.dynatrace.com/support/help/shortlink/configuration-as-code-manage-configuration#prerequisites) to see which scopes are required
+export DT_OAUTH_CLIENT_ID=""            # Check "Create OAuth token" page to do this - https://www.dynatrace.com/support/help/manage/configuration-as-code/guides/create-oauth-client 
+export DT_OAUTH_CLIENT_SECRET=""        # Same as above
+export DT_OAUTH_SSO_ENDPOINT=""         # Example - https://sso.dynatrace.com/sso/oauth2/token
+
+echo "$JIRA_URL"
+echo "$USER_EMAIL"
+echo "$JIRA_TOKEN"
+echo "$SLACK_BOT_TOKEN"
+echo "$SLACK_CHANNEL"
+echo "$JIRA_PROJECT"
+echo "$JIRA_ISSUE_TYPE"
+echo "$JIRA_TICKET_REPORTER"
+echo "$JIRA_TRANSITION_STATUS"
+echo "$AZURE_TENANT_ID"
+echo "$DT_API_TOKEN"
+echo "$DT_OAUTH_CLIENT_ID"
+echo "$DT_OAUTH_CLIENT_SECRET"
+echo "$DT_OAUTH_SSO_ENDPOINT"
+
+
+
+

--- a/VM-RIght-Sizing/script/input-needed.sh
+++ b/VM-RIght-Sizing/script/input-needed.sh
@@ -23,7 +23,6 @@ export DT_URL=""                        # Add your Dynatrace Tenant URL - e.g. h
 export DT_API_TOKEN=""                  # Dynatrace API token - Check prerequisite here (https://www.dynatrace.com/support/help/shortlink/configuration-as-code-manage-configuration#prerequisites) to see which scopes are required
 export DT_OAUTH_CLIENT_ID=""            # Check "Create OAuth token" page to do this - https://www.dynatrace.com/support/help/manage/configuration-as-code/guides/create-oauth-client 
 export DT_OAUTH_CLIENT_SECRET=""        # Same as above
-export DT_OAUTH_SSO_ENDPOINT=""         # Example - https://sso.dynatrace.com/sso/oauth2/token
 
 echo "$JIRA_URL"
 echo "$USER_EMAIL"
@@ -39,7 +38,7 @@ echo "$DT_URL"
 echo "$DT_API_TOKEN"
 echo "$DT_OAUTH_CLIENT_ID"
 echo "$DT_OAUTH_CLIENT_SECRET"
-echo "$DT_OAUTH_SSO_ENDPOINT"
+
 
 
 

--- a/VM-RIght-Sizing/script/input-needed.sh
+++ b/VM-RIght-Sizing/script/input-needed.sh
@@ -1,5 +1,4 @@
 #!/bin/sh 
-#  ^^ - change to SH if needed
 
 #Customer inputs - Jira and Slack app connections
 export JIRA_URL=""                      # Jira Connection url e.g. https://<url>.atlassian.net

--- a/VM-RIght-Sizing/script/input-needed.sh
+++ b/VM-RIght-Sizing/script/input-needed.sh
@@ -19,6 +19,7 @@ export BEARER_SCOPE=""                  # Payload for bearer token - scope e.g. 
 export BEARER_CLIENT_SECRET=""          # Payload for bearer token - client secret
 
 #Dynatrace variables needed
+export DT_URL=""                        # Add your Dynatrace Tenant URL - e.g. https://<tenantId>.apps.dynatrace.com/
 export DT_API_TOKEN=""                  # Dynatrace API token - Check prerequisite here (https://www.dynatrace.com/support/help/shortlink/configuration-as-code-manage-configuration#prerequisites) to see which scopes are required
 export DT_OAUTH_CLIENT_ID=""            # Check "Create OAuth token" page to do this - https://www.dynatrace.com/support/help/manage/configuration-as-code/guides/create-oauth-client 
 export DT_OAUTH_CLIENT_SECRET=""        # Same as above
@@ -34,6 +35,7 @@ echo "$JIRA_ISSUE_TYPE"
 echo "$JIRA_TICKET_REPORTER"
 echo "$JIRA_TRANSITION_STATUS"
 echo "$AZURE_TENANT_ID"
+echo "$DT_URL"
 echo "$DT_API_TOKEN"
 echo "$DT_OAUTH_CLIENT_ID"
 echo "$DT_OAUTH_CLIENT_SECRET"

--- a/VM-RIght-Sizing/script/input-needed.sh
+++ b/VM-RIght-Sizing/script/input-needed.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh 
+#!/bin/sh 
 #  ^^ - change to SH if needed
 
 #Customer inputs - Jira and Slack app connections

--- a/VM-RIght-Sizing/second-example/slack-connection/slack-connection.json
+++ b/VM-RIght-Sizing/second-example/slack-connection/slack-connection.json
@@ -1,0 +1,4 @@
+{
+        "name": "Slack Sandbox ",
+        "token": "{{ .slackToken }}"
+}

--- a/VM-RIght-Sizing/second-example/slack-connection/slack-connection.yaml
+++ b/VM-RIght-Sizing/second-example/slack-connection/slack-connection.yaml
@@ -1,0 +1,21 @@
+configs:
+- id: my.slack.connection
+  config:
+    name: my.slack.connection
+    template: slack-connection.json
+    parameters:
+      slackToken:
+        type: environment
+        name: SLACK_BOT_TOKEN
+      jira_Connection:
+        type: reference
+        project: jira-connection
+        configId: my.jira.connection
+        configType: app:dynatrace.jira:connection
+        property: id
+    skip: false
+  type:
+    settings:
+      schema: "app:dynatrace.slack:connection"
+      schemaVersion: 0.0.11
+      scope: environment

--- a/VM-RIght-Sizing/third-example/workflow-calculate-ticket/calculate-ticket.json
+++ b/VM-RIght-Sizing/third-example/workflow-calculate-ticket/calculate-ticket.json
@@ -1,0 +1,130 @@
+{
+    "title": "Host Resize - Calculate & Ticket",
+    "description": "",
+    "tasks": {
+      "get_cpu": {
+        "name": "get_cpu",
+        "description": "Identify hosts for right-sizing.",
+        "action": "dynatrace.automations:execute-dql-query",
+        "input": {
+          "query": "timeseries CPU = avg(dt.host.cpu.usage), from:now()-30d, to:now(), interval:30d, by:{dt.entity.host}\n| lookup sourceField:dt.entity.host, lookupField:id, [fetch dt.entity.host]\n| filter isNotNull(lookup.azureEnvironment)\n| filter CPU[1]>90 OR CPU[1]<15\n| fields Host = dt.entity.host,CPU=CPU[1]"
+        },
+        "position": {
+          "x": 0,
+          "y": 1
+        },
+        "predecessors": []
+      },
+      "notify_team": {
+        "name": "notify_team",
+        "description": "Notify team about new tickets.",
+        "action": "dynatrace.slack:slack-send-message",
+        "input": {
+          "channel": "{{ .slackChannel }}",
+          "message": "A new JIRA ticket with ID: {{ `{{` }} _.issue.id }} has been created.\n{{ `{{` }} _.issue.url }}",
+          "reaction": [],
+          "connection": "{{ .slack_Connection }}",
+          "workflowID": "{{ `{{` }} execution().workflow.id }}",
+          "executionID": "{{ `{{` }} execution().id }}",
+          "executionDate": "{{ `{{` }} execution().started_at }}",
+          "channelType": "id",
+          "appendToThread": false,
+          "selectedRequestType": 0,
+          "attachmentToggleValue": "none"
+        },
+        "position": {
+          "x": 0,
+          "y": 4
+        },
+        "predecessors": [
+          "move_to_pending"
+        ],
+        "conditions": {
+          "states": {
+            "move_to_pending": "OK"
+          }
+        },
+        "retry": {
+          "count": 2,
+          "delay": 10,
+          "failedLoopIterationsOnly": true
+        },
+        "concurrency": 1,
+        "withItems": "issue in {{ `{{` }}result(\"create_issue\")}}"
+      },
+      "create_issue": {
+        "name": "create_issue",
+        "description": "Open a ticket in JIRA for each host.",
+        "action": "dynatrace.jira:jira-create-issue",
+        "input": {
+          "labels": [],
+          "project": {
+            "id": "{{ .jiraProject }}"
+          },
+          "summary": "Hosts with possible upsize/downsize",
+          "assignee": null,
+          "priority": null,
+          "reporter": {
+            "id": "{{ .jiraTicketReporter }}"
+          },
+          "issueType": {
+            "id": "{{ .jiraIssueType }}"
+          },
+          "components": [],
+          "description": "{{ `{{` }} _.host.Host }} has a CPU of {{ `{{` }} _.host.CPU }}",
+          "connectionId": "{{ .jira_Connection }}",
+          "fieldSetters": []
+        },
+        "position": {
+          "x": 0,
+          "y": 2
+        },
+        "predecessors": [
+          "get_cpu"
+        ],
+        "conditions": {
+          "states": {
+            "get_cpu": "OK"
+          }
+        },
+        "concurrency": 1,
+        "withItems": "host in {{ `{{` }} result('get_cpu').records }}"
+      },
+      "move_to_pending": {
+        "name": "move_to_pending",
+        "description": "Transition the issue to 'pending'",
+        "action": "dynatrace.jira:jira-transition-issue",
+        "input": {
+          "issue": "{{ `{{` }} _.issue.id }}",
+          "comment": "DT Workflow moving to pending",
+          "project": "{{ .jiraProject }}",
+          "issueType": "{{ .jiraIssueType }}",
+          "connectionId": "{{ .jira_Connection }}",
+          "fieldSetters": [],
+          "targetStatus": "{{ .jiraTransitionStatus }}"
+        },
+        "position": {
+          "x": 0,
+          "y": 3
+        },
+        "predecessors": [
+          "create_issue"
+        ],
+        "conditions": {
+          "states": {
+            "create_issue": "OK"
+          },
+          "custom": ""
+        },
+        "retry": {
+          "count": 2,
+          "delay": 5,
+          "failedLoopIterationsOnly": true
+        },
+        "concurrency": 1,
+        "withItems": "issue in {{ `{{` }}result(\"create_issue\")}}"
+      }
+    },
+    "isPrivate": false,
+    "schemaVersion": 3
+  }

--- a/VM-RIght-Sizing/third-example/workflow-calculate-ticket/calculate-ticket.yaml
+++ b/VM-RIght-Sizing/third-example/workflow-calculate-ticket/calculate-ticket.yaml
@@ -1,0 +1,62 @@
+configs:
+- id: my.workflow
+  config:
+    name: my.workflow
+    template: calculate-ticket.json
+    parameters:
+      jiraProject:
+        type: environment
+        name: JIRA_PROJECT
+      slackChannel:
+        type: environment
+        name: SLACK_CHANNEL
+      jiraIssueType:
+        type: environment
+        name: JIRA_ISSUE_TYPE
+      jiraTicketReporter:
+        type: environment
+        name: JIRA_TICKET_REPORTER
+      jiraTransitionStatus:
+        type: environment
+        name: JIRA_TRANSITION_STATUS
+      slack_Connection:
+        type: reference
+        project: slack-connection
+        configId: my.slack.connection
+        configType: app:dynatrace.slack:connection
+        property: id
+      jira_Connection:
+        type: reference
+        project: jira-connection
+        configId: my.jira.connection
+        configType: app:dynatrace.jira:connection
+        property: id
+    skip: false
+  type:
+    automation:
+      resource: workflow
+- id: my.workflow.event
+  config:
+    name: my.workflow.event
+    template: event-trigger.json
+    parameters:
+      azureTenantId:
+        type: environment
+        name: AZURE_TENANT_ID
+      bearerClientId:
+        type: environment
+        name: BEARER_CLIENT_ID
+      bearerScope:
+        type: environment
+        name: BEARER_SCOPE
+      bearerClientSecret:
+        type: environment
+        name: BEARER_CLIENT_SECRET
+      order:
+          configId: my.workflow
+          property: id
+          type: reference
+    skip: false
+  type:
+    automation:
+      resource: workflow

--- a/VM-RIght-Sizing/third-example/workflow-calculate-ticket/event-trigger.json
+++ b/VM-RIght-Sizing/third-example/workflow-calculate-ticket/event-trigger.json
@@ -1,0 +1,169 @@
+{
+    "title": "Host Resize - Event Triggered",
+    "description": "",
+    "tasks": {
+      "upsize": {
+        "name": "upsize",
+        "description": "Upsize host",
+        "action": "dynatrace.automations:http-function",
+        "input": {
+          "url": "https://management.azure.com/subscriptions/{{ `{{` }}result(\"host_for_resizing\").records[0].AzureSubID }}/resourceGroups/{{ `{{` }}result(\"host_for_resizing\").records[0].AzureGroup }}/providers/Microsoft.Compute/virtualMachines/{{ `{{` }}result(\"host_for_resizing\").records[0].AzureName }}?api-version=2023-03-01",
+          "method": "PUT",
+          "headers": {
+            "Authorization": "Bearer {{ `{{` }} result(\"obtain_bearer_token\").json.access_token }}"
+          },
+          "payload": "{\n    \"properties\": {\n        \"hardwareProfile\": {\n            \"vmSize\": \"{{ `{{` }}result(\"host_for_resizing\").records[0].AzureUp }}\"\n        }\n    },\n    \"location\": \"West Europe\"\n}"
+        },
+        "position": {
+          "x": 1,
+          "y": 3
+        },
+        "predecessors": [
+          "obtain_bearer_token"
+        ],
+        "conditions": {
+          "states": {
+            "obtain_bearer_token": "OK"
+          },
+          "custom": "{{ `{{` }}result(\"host_for_resizing\").records[0].Cpu > 90 }}"
+        }
+      },
+      "downsize": {
+        "name": "downsize",
+        "description": "Downsize host",
+        "action": "dynatrace.automations:http-function",
+        "input": {
+          "url": "https://management.azure.com/subscriptions/{{ `{{` }}result(\"host_for_resizing\").records[0].AzureSubID }}/resourceGroups/{{ `{{` }}result(\"host_for_resizing\").records[0].AzureGroup }}/providers/Microsoft.Compute/virtualMachines/{{ `{{` }}result(\"host_for_resizing\").records[0].AzureName }}?api-version=2023-03-01",
+          "method": "PUT",
+          "headers": {
+            "Authorization": "Bearer {{ `{{` }} result(\"obtain_bearer_token\").json.access_token }}"
+          },
+          "payload": "{\n    \"properties\": {\n        \"hardwareProfile\": {\n            \"vmSize\": \"{{ `{{` }}result(\"host_for_resizing\").records[0].AzureDown }}\"\n        }\n    },\n    \"location\": \"West Europe\"\n}"
+        },
+        "position": {
+          "x": -1,
+          "y": 3
+        },
+        "predecessors": [
+          "obtain_bearer_token"
+        ],
+        "conditions": {
+          "states": {
+            "obtain_bearer_token": "OK"
+          },
+          "custom": "{{ `{{` }}result(\"host_for_resizing\").records[0].Cpu <15 }}"
+        }
+      },
+      "host_for_resizing": {
+        "name": "host_for_resizing",
+        "description": "Parse event trigger for details of host to rightsize",
+        "action": "dynatrace.automations:execute-dql-query",
+        "input": {
+          "query": "data record(description=\"{{ `{{` }} event()['issuedescription'] }}\")\n| parse description, \"LD:Host SPACE LD DOUBLE:Cpu\"\n| lookup sourceField:Host, lookupField:id, prefix:\"Azure\", [\nfetch dt.entity.host | fieldsAdd Group=azureResourceGroupName, T=toString(tags)\n]\n| parse AzureT, \"LD 'AzureSubscriptionID:'LD:AzureSubID'\\\"'\"\n| parse AzureT, \"LD 'AzureDownsize:'LD:AzureDown'\\\"'\"\n| parse AzureT, \"LD 'AzureUpsize:'LD:AzureUp'\\\"'\"\n| parse Azureentity.name, \"LD:AzureName'.'\"\n| fieldsKeep Cpu,AzureGroup, AzureSubID, AzureDown, AzureUp, AzureName"
+        },
+        "position": {
+          "x": 0,
+          "y": 1
+        },
+        "predecessors": [],
+        "conditions": {
+          "states": {},
+          "custom": ""
+        }
+      },
+      "obtain_bearer_token": {
+        "name": "obtain_bearer_token",
+        "description": "Request bearer token from Azure",
+        "action": "dynatrace.automations:http-function",
+        "input": {
+          "url": "https://login.microsoftonline.com/{{ .azureTenantId }}/oauth2/v2.0/token",
+          "method": "POST",
+          "headers": {
+            "Content-Type": "application/x-www-form-urlencoded"
+          },
+          "payload": "client_id={{ .bearerClientId }}&scope={{ .bearerScope }}&client_secret={{ .bearerClientSecret }}&grant_type=client_credentials"
+        },
+        "position": {
+          "x": 0,
+          "y": 2
+        },
+        "predecessors": [
+          "host_for_resizing"
+        ],
+        "conditions": {
+          "states": {
+            "host_for_resizing": "OK"
+          }
+        }
+      },
+      "upsize_close_ticket": {
+        "name": "upsize_close_ticket",
+        "description": "Close ticket as work completed",
+        "action": "dynatrace.jira:jira-transition-issue",
+        "input": {
+          "issue": "{{ `{{` }} event()[\"issueid\"] }}",
+          "comment": "Dt moving to done",
+          "project": "{{ .jiraProject }}",
+          "issueType": "{{ .jiraIssueType }}",
+          "connectionId": "{{ .jira_Connection }}",
+          "fieldSetters": [],
+          "targetStatus": "{{ .jiraTransitionStatus }}"
+        },
+        "position": {
+          "x": 1,
+          "y": 4
+        },
+        "predecessors": [
+          "upsize"
+        ],
+        "conditions": {
+          "states": {
+            "upsize": "OK"
+          }
+        }
+      },
+      "downsize_close_ticket": {
+        "name": "downsize_close_ticket",
+        "description": "Close ticket as work completed",
+        "action": "dynatrace.jira:jira-transition-issue",
+        "input": {
+          "issue": "{{ `{{` }} event()[\"issueid\"] }}",
+          "comment": "DT moving to done",
+          "project": "{{ .jiraProject }}",
+          "issueType": "{{ .jiraIssueType }}",
+          "connectionId": "{{ .jira_Connection }}",
+          "fieldSetters": [],
+          "targetStatus": "{{ .jiraTransitionStatus }}"
+        },
+        "position": {
+          "x": -1,
+          "y": 4
+        },
+        "predecessors": [
+          "downsize"
+        ],
+        "conditions": {
+          "states": {
+            "downsize": "OK"
+          }
+        }
+      }
+    },
+    "ownerType": "USER",
+    "isPrivate": false,
+    "trigger": {
+      "eventTrigger": {
+        "filterQuery": "matchesPhrase(event.name, \"Jira approval granted\")",
+        "isActive": true,
+        "uniqueExpression": null,
+        "triggerConfiguration": {
+          "type": "event",
+          "value": {
+            "query": "matchesPhrase(event.name, \"Jira approval granted\")",
+            "eventType": "events"
+          }
+        }
+      }
+    },
+    "schemaVersion": 3
+  }


### PR DESCRIPTION
Adding our vm right sizing example from [the community tips and tricks episode #13 ](https://www.youtube.com/watch?v=dGWlnd1lNGQ). This was done manually, however, I've automated it with Monaco and a colleague suggested that I upload this as an example here. 
The repo consists of 3 smaller projects - slack, jira and workflows. It also contains the delete file to be used with the delete command and the script that will take the values and import them as env variables. 
If there are any questions, please let me know.