### PR TITLE
Jira target status change in a workflow

### DIFF
--- a/VM-RIght-Sizing/script/input-needed.sh
+++ b/VM-RIght-Sizing/script/input-needed.sh
@@ -11,7 +11,8 @@ export SLACK_CHANNEL=""                 # ID of the Slack channel notifications 
 export JIRA_PROJECT=""                  # Jira Project ID
 export JIRA_ISSUE_TYPE="" -             # Jira issue type in an ID format
 export JIRA_TICKET_REPORTER=""          # Jira ticket reporter in an ID format
-export JIRA_TRANSITION_STATUS=""        # Jira transition status in an ID format
+export JIRA_TRANSITION_STATUS=""        # Jira transition status for "pending" in an ID format
+export JIRA_CLOSE_TICKET=""             # Jira transition status for "done" in an ID format
 export AZURE_TENANT_ID="" 
 export BEARER_CLIENT_ID=""              # Payload for bearer token - client ID
 export BEARER_SCOPE=""                  # Payload for bearer token - scope e.g. https%3A%2F%2Fmanagement.azure.com%2F.default
@@ -32,6 +33,7 @@ echo "$JIRA_PROJECT"
 echo "$JIRA_ISSUE_TYPE"
 echo "$JIRA_TICKET_REPORTER"
 echo "$JIRA_TRANSITION_STATUS"
+echo "$JIRA_CLOSE_TICKET"
 echo "$AZURE_TENANT_ID"
 echo "$DT_URL"
 echo "$DT_API_TOKEN"

--- a/VM-RIght-Sizing/third-example/workflow-calculate-ticket/calculate-ticket.yaml
+++ b/VM-RIght-Sizing/third-example/workflow-calculate-ticket/calculate-ticket.yaml
@@ -64,6 +64,9 @@ configs:
       jiraTransitionStatus:
         type: environment
         name: JIRA_TRANSITION_STATUS
+      jiraCloseTicket:
+        type: environment
+        name: JIRA_CLOSE_TICKET
       jira_Connection:
         type: reference
         project: jira-connection

--- a/VM-RIght-Sizing/third-example/workflow-calculate-ticket/calculate-ticket.yaml
+++ b/VM-RIght-Sizing/third-example/workflow-calculate-ticket/calculate-ticket.yaml
@@ -52,6 +52,24 @@ configs:
       bearerClientSecret:
         type: environment
         name: BEARER_CLIENT_SECRET
+      jiraProject:
+        type: environment
+        name: JIRA_PROJECT
+      jiraIssueType:
+        type: environment
+        name: JIRA_ISSUE_TYPE
+      jiraTicketReporter:
+        type: environment
+        name: JIRA_TICKET_REPORTER
+      jiraTransitionStatus:
+        type: environment
+        name: JIRA_TRANSITION_STATUS
+      jira_Connection:
+        type: reference
+        project: jira-connection
+        configId: my.jira.connection
+        configType: app:dynatrace.jira:connection
+        property: id
       order:
           configId: my.workflow
           property: id

--- a/VM-RIght-Sizing/third-example/workflow-calculate-ticket/event-trigger.json
+++ b/VM-RIght-Sizing/third-example/workflow-calculate-ticket/event-trigger.json
@@ -107,7 +107,7 @@
           "issueType": "{{ .jiraIssueType }}",
           "connectionId": "{{ .jira_Connection }}",
           "fieldSetters": [],
-          "targetStatus": "{{ .jiraTransitionStatus }}"
+          "targetStatus": "{{ .jiraCloseTicket }}"
         },
         "position": {
           "x": 1,
@@ -133,7 +133,7 @@
           "issueType": "{{ .jiraIssueType }}",
           "connectionId": "{{ .jira_Connection }}",
           "fieldSetters": [],
-          "targetStatus": "{{ .jiraTransitionStatus }}"
+          "targetStatus": "{{ .jiraCloseTicket }}"
         },
         "position": {
           "x": -1,


### PR DESCRIPTION
Making necessary changes to the files so we can change the jiraTransitionStatus env variable over to the jiraCloseTicket because the worfklow kept the jira ticket in pending instead of transferring it over to "done". With these changes, that will be possible.