### PR TITLE
Set schema version to 1.1.0 for SRG template

### DIFF
--- a/site_reliability_guardian_sample/srg-config-as-code/configs.yaml
+++ b/site_reliability_guardian_sample/srg-config-as-code/configs.yaml
@@ -28,7 +28,7 @@ configs:
   type:
     settings:
       schema: app:dynatrace.site.reliability.guardian:guardians
-      schemaVersion: 1.1
+      schemaVersion: 1.1.0
       scope: environment
 - id: easytradeworkflow
   config:

--- a/site_reliability_guardian_sample/srg-config-as-code/configs.yaml
+++ b/site_reliability_guardian_sample/srg-config-as-code/configs.yaml
@@ -28,7 +28,7 @@ configs:
   type:
     settings:
       schema: app:dynatrace.site.reliability.guardian:guardians
-      schemaVersion: 1.0.2
+      schemaVersion: 1.1
       scope: environment
 - id: easytradeworkflow
   config:


### PR DESCRIPTION
Due to an update for SRG to version 1.6.0, the schema version increased from 1.0.2 to 1.1