### PR TITLE
feat: Add `segments` example

### DIFF
--- a/segment-with-dashboard/README.md
+++ b/segment-with-dashboard/README.md
@@ -1,0 +1,31 @@
+# Dynatrace Segments
+
+This example shows how [Dynatrace Segments] can be configured and managed using Monaco.
+
+The example provides the `segments` project with two configurations. First, the `segment` configuration, and second, the `dashboard` configuration.\
+The dashboard depends on the segment to automatically include the segment.
+
+## Requirements
+
+- Monaco `v2.19.0+`
+- Dynatrace Platform environment
+- OAuth credentials as described [here][OAuth credentials], including the additional scopes:  
+  `storage:filter-segments:read`, `storage:filter-segments:write`, `storage:filter-segments:delete`.
+
+
+## Monaco commands
+
+### Creating the configuration
+
+```shell
+monaco deploy manifest.yaml
+```
+
+### Delete the created configuration
+
+```shell
+monaco delete -m manifest.yaml
+```
+
+[Dynatrace Segments]: https://docs.dynatrace.com/docs/manage/segments
+[OAuth credentials]: https://www.dynatrace.com/support/help/manage/configuration-as-code/guides/create-oauth-client#create-an-oauth-client

--- a/segment-with-dashboard/delete.yaml
+++ b/segment-with-dashboard/delete.yaml
@@ -1,0 +1,9 @@
+# generated using `monaco generate deletefile manifest.yaml`
+
+delete:
+- project: segments
+  type: document
+  id: dashboard
+- project: segments
+  type: segment
+  id: segment

--- a/segment-with-dashboard/manifest.yaml
+++ b/segment-with-dashboard/manifest.yaml
@@ -1,0 +1,18 @@
+manifestVersion: 1.0
+
+projects:
+- name: segments
+
+environmentGroups:
+- name: default
+  environments:
+  - name: kci
+    url:
+      type: environment
+      value: ENVIRONMENT_URL
+    auth:
+      oAuth:
+        clientId:
+          name: OAUTH_CLIENT_ID
+        clientSecret:
+          name: OAUTH_CLIENT_SECRET

--- a/segment-with-dashboard/segments/_config.yaml
+++ b/segment-with-dashboard/segments/_config.yaml
@@ -1,0 +1,22 @@
+configs:
+
+- id: segment
+  type: segment
+  config:
+    template: segment.json
+
+
+- id: dashboard
+  type:
+    document:
+      kind: dashboard
+      private: true
+  config:
+    name: Log Dashboard with Dynatrace Segment
+    parameters:
+      segment_id:
+        configId: segment
+        configType: segment
+        property: id
+        type: reference
+    template: dashboard.json

--- a/segment-with-dashboard/segments/dashboard.json
+++ b/segment-with-dashboard/segments/dashboard.json
@@ -1,0 +1,61 @@
+{
+  "version": 17,
+  "variables": [],
+  "tiles": {
+    "0": {
+      "davis": {},
+      "query": "fetch logs\n| limit 20",
+      "queryConfig": {
+        "globalCommands": {
+          "limit": 20
+        },
+        "subQueries": [
+          {
+            "datatype": "logs",
+            "id": "A",
+            "isEnabled": true
+          }
+        ],
+        "version": "12.5.1"
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      },
+      "subType": "dql-builder-logs",
+      "title": "",
+      "type": "data",
+      "visualization": "table"
+    }
+  },
+  "layouts": {
+    "0": {
+      "x": 0,
+      "y": 0,
+      "w": 24,
+      "h": 8
+    }
+  },
+  "importedWithCode": false,
+  "settings": {
+    "defaultSegments": {
+      "value": [
+        {
+          "id": "{{.segment_id}}",
+          "variables": [
+            {
+              "name": "entity.name",
+              "values": [
+                "kube-system"
+              ]
+            }
+          ]
+        }
+      ],
+      "enabled": true
+    }
+  }
+}

--- a/segment-with-dashboard/segments/segment.json
+++ b/segment-with-dashboard/segments/segment.json
@@ -1,0 +1,22 @@
+{
+  "name": "Logs - Kubernetes Namespace name",
+  "description": "Filter logs for Kubernetes namespace names",
+  "isPublic": true,
+  "variables": {
+    "type": "query",
+    "value": "fetch dt.entity.cloud_application_namespace\n| fields entity.name"
+  },
+  "includes": [
+    {
+      "filter": "{\"type\":\"Group\",\"range\":{\"from\":0,\"to\":36},\"logicalOperator\":\"AND\",\"explicit\":false,\"children\":[{\"type\":\"Statement\",\"range\":{\"from\":0,\"to\":35},\"key\":{\"type\":\"Key\",\"textValue\":\"k8s.namespace.name\",\"value\":\"k8s.namespace.name\",\"range\":{\"from\":0,\"to\":18}},\"operator\":{\"type\":\"ComparisonOperator\",\"textValue\":\"=\",\"value\":\"=\",\"range\":{\"from\":19,\"to\":20}},\"value\":{\"type\":\"String\",\"textValue\":\"\\\"$entity.name\\\"\",\"value\":\"$entity.name\",\"range\":{\"from\":21,\"to\":35},\"isEscaped\":true}}]}",
+      "dataObject": "logs",
+      "applyTo": []
+    }
+  ],
+  "allowedOperations": [
+    "READ",
+    "WRITE",
+    "DELETE",
+    "SHARE"
+  ]
+}


### PR DESCRIPTION
This PR adds an example of how customers may use Monaco to configure Dynatrace Segments.

The example includes a dashboard to show how segments may be used to filter data in Dynatrace.