### PR TITLE
Set Dashboards for GitHub and AZDO to public

### DIFF
--- a/azure_devops_observability/pipeline_observability/document-dashboard/config.yaml
+++ b/azure_devops_observability/pipeline_observability/document-dashboard/config.yaml
@@ -8,7 +8,7 @@ configs:
   type:
     document:
       kind: dashboard
-      private: true
+      private: false
 - id: ec7a0de0-04fa-4726-b34b-dfcde20d3c69
   config:
     name: Azure DevOps Pipelines
@@ -18,7 +18,7 @@ configs:
   type:
     document:
       kind: dashboard
-      private: true
+      private: false
 - id: d66880a7-9a33-4991-9ef4-998463852fab
   config:
     name: Azure DevOps Deployments
@@ -28,4 +28,4 @@ configs:
   type:
     document:
       kind: dashboard
-      private: true
+      private: false

--- a/github_pipeline_observability/pipeline_observability/document-dashboard/config.yaml
+++ b/github_pipeline_observability/pipeline_observability/document-dashboard/config.yaml
@@ -8,7 +8,7 @@ configs:
   type:
     document:
       kind: dashboard
-      private: true
+      private: false
 - id: a6fcb6d1-0ddb-4ab8-aff9-31afb2808501
   config:
     name: GitHub Pull Requests
@@ -18,4 +18,4 @@ configs:
   type:
     document:
       kind: dashboard
-      private: true
+      private: false


### PR DESCRIPTION
While the dashboards for GitLab and ArgoCD are set to public, GitHub and AZDO are private. This PR makes them public. 